### PR TITLE
댓글 작성, 수정, 삭제, 조회 기능 구현 

### DIFF
--- a/src/main/java/com/service/runnersmap/config/SecurityConfig.java
+++ b/src/main/java/com/service/runnersmap/config/SecurityConfig.java
@@ -30,8 +30,8 @@ public class SecurityConfig {
         // HTTP 요청에 대한 권한
         .authorizeHttpRequests(auth -> auth
             .requestMatchers(
-                "api/user/sign-up",
-                "api/user/login"
+                "/api/user/sign-up",
+                "/api/user/login"
             ).permitAll()
             .anyRequest().authenticated()
         )

--- a/src/main/java/com/service/runnersmap/config/WebConfig.java
+++ b/src/main/java/com/service/runnersmap/config/WebConfig.java
@@ -10,8 +10,8 @@ public class WebConfig implements WebMvcConfigurer {
   @Override
   public void addCorsMappings(CorsRegistry registry) {
     registry.addMapping("/**")
-        .allowedOrigins("*")
-        .allowedMethods("GET", "POST", "PUT", "DELETE")
+        .allowedOriginPatterns("*")
+        .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
         .allowedHeaders("*")
         .allowCredentials(true);
   }

--- a/src/main/java/com/service/runnersmap/controller/CommentController.java
+++ b/src/main/java/com/service/runnersmap/controller/CommentController.java
@@ -1,0 +1,97 @@
+package com.service.runnersmap.controller;
+
+import com.service.runnersmap.dto.CommentDto;
+import com.service.runnersmap.entity.User;
+import com.service.runnersmap.exception.RunnersMapException;
+import com.service.runnersmap.repository.UserRepository;
+import com.service.runnersmap.service.CommentService;
+import com.service.runnersmap.type.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+  private final CommentService commentService;
+  private final UserRepository userRepository;
+
+  // 댓글 작성
+  @PostMapping("/{postId}")
+  public ResponseEntity<Void> createComment(
+      @AuthenticationPrincipal UserDetails userDetails,
+      @PathVariable Long postId,
+      @RequestBody CommentDto commentDto)  {
+
+    User user = getCurrentUser(userDetails);
+
+    commentService.createComment(postId, user.getId(), commentDto);
+    return ResponseEntity.status((HttpStatus.CREATED)).build(); //201 Created
+  }
+
+
+  // 댓글 수정
+  @PatchMapping("/{commentId}")
+  public ResponseEntity<Void> updateComment(
+      @AuthenticationPrincipal UserDetails userDetails,
+      @PathVariable Long commentId,
+      @RequestBody CommentDto commentDto) {
+
+    User user = getCurrentUser(userDetails);
+
+    commentService.updateComment(commentId, user.getId(), commentDto);
+    return ResponseEntity.ok().build(); // 200 OK
+  }
+
+
+  // 댓글 삭제
+  @DeleteMapping("/{commentId}")
+  public ResponseEntity<Void> deleteComment(
+      @PathVariable Long commentId,
+      @AuthenticationPrincipal UserDetails userDetails) {
+
+    User user = getCurrentUser(userDetails);
+
+    commentService.deleteComment(commentId, user.getId());
+    return ResponseEntity.noContent().build(); // 204 No Content
+  }
+
+
+  // 댓글 조회
+  @GetMapping("/{postId}")
+  public ResponseEntity<Page<CommentDto>> getComments(
+      @PathVariable Long postId,
+      @AuthenticationPrincipal UserDetails userDetails,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "20") int size) {
+
+    User user = getCurrentUser(userDetails);
+
+    Page<CommentDto> commentDtos = commentService.getComments(postId, user.getId(),
+        PageRequest.of(page, size));
+    return ResponseEntity.ok(commentDtos);  // 200 OK
+  }
+
+  // 사용자 정보 조회
+  private User getCurrentUser(@AuthenticationPrincipal UserDetails userDetails) {
+    String email = userDetails.getUsername();
+    return userRepository.findByEmail(email)
+        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_FOUND_USER));
+  }
+}
+

--- a/src/main/java/com/service/runnersmap/dto/CommentDto.java
+++ b/src/main/java/com/service/runnersmap/dto/CommentDto.java
@@ -1,0 +1,17 @@
+package com.service.runnersmap.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommentDto {
+
+  private String nickname;
+  private String content;
+}

--- a/src/main/java/com/service/runnersmap/dto/CommentDto.java
+++ b/src/main/java/com/service/runnersmap/dto/CommentDto.java
@@ -14,4 +14,5 @@ public class CommentDto {
 
   private String nickname;
   private String content;
+  private LocalDateTime createdAt;
 }

--- a/src/main/java/com/service/runnersmap/entity/Comment.java
+++ b/src/main/java/com/service/runnersmap/entity/Comment.java
@@ -1,0 +1,43 @@
+package com.service.runnersmap.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+public class Comment {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "post_id")
+  private Post post;    // 댓글이 달린 모집글
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "users_id")
+  private User user;  // 댓글 작성자
+
+  private String content; // 댓글 내용
+
+  private LocalDateTime createdAt;
+
+  private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/service/runnersmap/repository/CommentRepository.java
+++ b/src/main/java/com/service/runnersmap/repository/CommentRepository.java
@@ -1,0 +1,15 @@
+package com.service.runnersmap.repository;
+
+import com.service.runnersmap.entity.Comment;
+import com.service.runnersmap.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+
+  Page<Comment> findByPost(Post post, Pageable pageable);
+}

--- a/src/main/java/com/service/runnersmap/service/CommentService.java
+++ b/src/main/java/com/service/runnersmap/service/CommentService.java
@@ -1,0 +1,131 @@
+package com.service.runnersmap.service;
+
+import com.service.runnersmap.dto.CommentDto;
+import com.service.runnersmap.entity.Comment;
+import com.service.runnersmap.entity.Post;
+import com.service.runnersmap.entity.User;
+import com.service.runnersmap.entity.UserPost;
+import com.service.runnersmap.entity.UserPostPK;
+import com.service.runnersmap.exception.RunnersMapException;
+import com.service.runnersmap.repository.CommentRepository;
+import com.service.runnersmap.repository.PostRepository;
+import com.service.runnersmap.repository.UserPostRepository;
+import com.service.runnersmap.repository.UserRepository;
+import com.service.runnersmap.type.ErrorCode;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CommentService {
+
+  private final CommentRepository commentRepository;
+  private final PostRepository postRepository;
+  private final UserRepository userRepository;
+  private final UserPostRepository userPostRepository;
+
+  /**
+   * 댓글 작성 - 해당 모집글에 참여한 사용자만 작성 가능
+   */
+  @Transactional
+  public void createComment(Long postId, Long userId, CommentDto commentDto) {
+
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_FOUND_POST_DATA));
+
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_FOUND_USER));
+
+    UserPost userPost = userPostRepository.findById(new UserPostPK(user, post))
+        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_POST_INCLUDE_USER));
+
+    if (!userPost.getValid_yn()) {
+      throw new RunnersMapException(ErrorCode.NOT_POST_INCLUDE_USER);
+    }
+
+    // 댓글 작성
+    Comment comment = Comment.builder()
+        .post(post)
+        .user(user)
+        .content(commentDto.getContent())
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+    commentRepository.save(comment);
+    log.info("댓글 작성 완료: {}", comment.getContent());
+  }
+
+  /**
+   * 특정 모집글의 댓글 조회 - 해당 모집글에 참여한 사용자만 조회 가능
+   */
+  @Transactional(readOnly = true)
+  public Page<CommentDto> getComments(Long postId, Long userId, Pageable pageable) {
+
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_FOUND_POST_DATA));
+
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_FOUND_USER));
+
+    UserPost userPost = userPostRepository.findById(new UserPostPK(user, post))
+        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_POST_INCLUDE_USER));
+
+    if (!userPost.getValid_yn()) {
+      throw new RunnersMapException(ErrorCode.NOT_POST_INCLUDE_USER);
+    }
+
+    return commentRepository.findByPost(post, pageable)
+        .map(comment -> new CommentDto(
+            comment.getUser().getNickname(),
+            comment.getContent()
+        ));
+  }
+
+  /**
+   * 댓글 수정 댓글 작성자만 수정 가능
+   */
+  @Transactional
+  public void updateComment(Long commentId, Long userId, CommentDto commentDto) {
+    log.info("댓글 수정 요청 - 댓글 ID: {}, 사용자 ID: {}", commentId, userId);
+
+    Comment comment = commentRepository.findById(commentId)
+        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_FOUND_COMMENT));
+
+    log.info("댓글 작성자 ID: {}", comment.getUser().getId());
+
+    if (!comment.getUser().getId().equals(userId)) {
+      log.error("댓글 작성자만 댓글 수정 가능 - 사용자 ID: {}", userId);
+      throw new RunnersMapException(ErrorCode.WRITER_ONLY_ACCESS_COMMENT_DATA);
+    }
+
+    comment.setContent(commentDto.getContent());
+    comment.setUpdatedAt(LocalDateTime.now());
+    commentRepository.save(comment);
+    log.info("댓글 수정 완료");
+  }
+
+  /**
+   * 댓글 삭제 댓글 작성자만 삭제 가능
+   */
+  @Transactional
+  public void deleteComment(Long commentId, Long userId) {
+    log.info("댓글 삭제 요청");
+
+    Comment comment = commentRepository.findById(commentId)
+        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_FOUND_COMMENT));
+
+    if (!comment.getUser().getId().equals(userId)) {
+      log.error("댓글 작성자만 댓글 삭제 가능");
+      throw new RunnersMapException(ErrorCode.WRITER_ONLY_ACCESS_COMMENT_DATA);
+    }
+
+    commentRepository.delete(comment);
+    log.info("댓글 삭제 완료");
+  }
+}

--- a/src/main/java/com/service/runnersmap/type/ErrorCode.java
+++ b/src/main/java/com/service/runnersmap/type/ErrorCode.java
@@ -32,9 +32,13 @@ public enum ErrorCode {
 
   NOT_VALID_PASSWORD("비밀번호를 다시 확인해주세요"),
 
-  ALREADY_EXISTS_NICKNAME("이미 사용중인 닉네임입니다.")
+  ALREADY_EXISTS_NICKNAME("이미 사용중인 닉네임입니다."),
 
 
+  // 댓글 관련 에러코드
+  NOT_FOUND_COMMENT("댓글이 존재하지 않습니다."),
+
+  WRITER_ONLY_ACCESS_COMMENT_DATA("댓글 작성자만 수정/삭제가 가능합니다.")
   ;
 
   private final String description;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
-  CORS 관련하여 로컬 내에서 문제가 발생하여 수정하였습니다. 
- 로그인 된 상태이면서 그룹에 참여한 상태의 사람들만 사용할 수 있는 기능입니다.
- 댓글 수정, 삭제는 작성자만 할 수 있습니다.
- 댓글 조회는 페이징처리하여 사이즈는 20으로 처리해두었습니다. 
- 댓글 조회시 작성자의 닉네임, 댓글내용, 댓글 생성시간을 조회할 수 있습니다. 

**TO-BE**
-  CORS 관련하여 설정이 바뀌었기 때문에 FE 분들의 확인이 필요할 것 같습니다. 

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
