### PR TITLE
Feature/login : 리프레시 토큰으로 엑세스 토큰 재발급 

### DIFF
--- a/src/main/java/com/service/runnersmap/component/JwtTokenProvider.java
+++ b/src/main/java/com/service/runnersmap/component/JwtTokenProvider.java
@@ -33,7 +33,7 @@ public class JwtTokenProvider {
         .setExpiration(new Date(System.currentTimeMillis() + TOKEN_EXPIRED_TIME)) // 만료시간
         .signWith(algorithm, secretKey)
         .compact(); // 토큰을 문자열로 변환하여 반환
-    log.info("생성된 Access Token : {}", token);
+    log.info("엑세스 토큰 : {}", token);
     return token;
   }
 

--- a/src/main/java/com/service/runnersmap/config/SecurityConfig.java
+++ b/src/main/java/com/service/runnersmap/config/SecurityConfig.java
@@ -31,7 +31,9 @@ public class SecurityConfig {
         .authorizeHttpRequests(auth -> auth
             .requestMatchers(
                 "/api/user/sign-up",
-                "/api/user/login"
+                "/api/user/login",
+                "/api/user/refresh"
+
             ).permitAll()
             .anyRequest().authenticated()
         )

--- a/src/main/java/com/service/runnersmap/controller/UserController.java
+++ b/src/main/java/com/service/runnersmap/controller/UserController.java
@@ -1,11 +1,12 @@
 package com.service.runnersmap.controller;
 
-import com.service.runnersmap.dto.TokenResponse;
+import com.service.runnersmap.dto.LoginResponse;
 import com.service.runnersmap.dto.UserDto.AccountDeleteDto;
 import com.service.runnersmap.dto.UserDto.AccountInfoDto;
 import com.service.runnersmap.dto.UserDto.AccountUpdateDto;
 import com.service.runnersmap.dto.UserDto.LoginDto;
 import com.service.runnersmap.dto.UserDto.SignUpDto;
+import com.service.runnersmap.entity.RefreshToken;
 import com.service.runnersmap.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -37,8 +38,8 @@ public class UserController {
 
   // 로그인 API
   @PostMapping("/login")
-  public ResponseEntity<TokenResponse> login(@RequestBody LoginDto loginDto) {
-    TokenResponse tokenResponse = userService.login(loginDto);
+  public ResponseEntity<LoginResponse> login(@RequestBody LoginDto loginDto) {
+    LoginResponse tokenResponse = userService.login(loginDto);
     return ResponseEntity.ok(tokenResponse); // 200 OK
   }
 
@@ -85,6 +86,16 @@ public class UserController {
     String email = userDetails.getUsername();
     userService.updateAccount(email, accountUpdateDto);
     return ResponseEntity.ok().build(); // 200 OK
+
+  }
+
+
+  // 리프레시 토큰으로 엑세스 토큰 갱신
+  @PostMapping("/refresh")
+  public ResponseEntity<LoginResponse> refreshToken(@RequestBody LoginResponse refreshToken) {
+
+    LoginResponse newTokenResponse = userService.refreshAccessToken(refreshToken.getRefreshToken());
+    return ResponseEntity.ok(newTokenResponse);
 
   }
 }

--- a/src/main/java/com/service/runnersmap/dto/LoginResponse.java
+++ b/src/main/java/com/service/runnersmap/dto/LoginResponse.java
@@ -7,8 +7,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class TokenResponse {
+public class LoginResponse {
   private String accessToken;
   private String refreshToken;
-
+  private Long userId; // 사용자 ID
+  private String nickname; // 사용자 닉네임
+  private String lastPosition; // 사용자 마지막 위치
 }

--- a/src/main/java/com/service/runnersmap/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/service/runnersmap/repository/RefreshTokenRepository.java
@@ -2,9 +2,13 @@ package com.service.runnersmap.repository;
 
 import com.service.runnersmap.entity.RefreshToken;
 import com.service.runnersmap.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
+
   void deleteByUser(User user);
+
+  Optional<RefreshToken> findByToken(String token);
 }

--- a/src/main/java/com/service/runnersmap/type/ErrorCode.java
+++ b/src/main/java/com/service/runnersmap/type/ErrorCode.java
@@ -33,6 +33,8 @@ public enum ErrorCode {
   NOT_FOUND_PARTICIPATE_USER("해당 이용자는 이미 모집글에 참여하지 않는 이용자 입니다."),
 
   // 유저 관련 에러코드
+  INVALID_REFRESH_TOKEN("유효하지 않은 토큰입니다."),
+
   ALREADY_EXISTS_USER("이미 회원가입 된 이메일입니다."),
 
   NOT_VALID_PASSWORD("비밀번호를 다시 확인해주세요"),


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
리프레시 토큰으로 엑세스 토큰 재발급 받는 로직을 추가했습니다. 
Response로는 로그인 때와 똑같이 new엑세스토큰, 리프레시토큰, 사용자id, 닉네임, 마지막 위치 입니다.
요청 헤더는 없습니다. 

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
