### PR TITLE
Feat : 인증샷 업로드, 조회, 좋아요

### DIFF
--- a/src/main/java/com/service/runnersmap/controller/AfterRunController.java
+++ b/src/main/java/com/service/runnersmap/controller/AfterRunController.java
@@ -1,0 +1,69 @@
+package com.service.runnersmap.controller;
+
+import com.service.runnersmap.dto.AfterRunPictureDto;
+import com.service.runnersmap.entity.User;
+import com.service.runnersmap.exception.RunnersMapException;
+import com.service.runnersmap.repository.UserRepository;
+import com.service.runnersmap.service.AfterRunService;
+import com.service.runnersmap.type.ErrorCode;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/posts/{postId}/after-run-pictures")
+@RequiredArgsConstructor
+public class AfterRunController {
+
+  private final AfterRunService afterRunService;
+  private final UserRepository userRepository;
+
+  // 인증샷 업로드
+  @PostMapping
+  public ResponseEntity<AfterRunPictureDto> uploadAfterRunPicture(
+      @AuthenticationPrincipal UserDetails userDetails,
+      @PathVariable Long postId,
+      @RequestParam("file") MultipartFile file) throws IOException {
+
+    User user = getCurrentUser(userDetails);
+    AfterRunPictureDto afterRunPictureDto = afterRunService.createAfterRunPicture(postId, user.getId(), file);
+    return ResponseEntity.status(HttpStatus.CREATED).body(afterRunPictureDto);  // 201 Created
+  }
+
+  // 인증샷 조회
+  @GetMapping
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<AfterRunPictureDto> getAfterRunPicture(
+      @PathVariable Long postId) {
+    AfterRunPictureDto afterRunPictureDto = afterRunService.viewAfterRunPicture(postId);
+    return ResponseEntity.ok(afterRunPictureDto); // 200 OK
+  }
+
+  // 좋아요
+  @PostMapping("/{fileId}/like")
+  public ResponseEntity<Void> toggleLike(
+      @PathVariable Long postId,
+      @PathVariable Long fileId,
+      @AuthenticationPrincipal UserDetails userDetails) {
+    User user = getCurrentUser(userDetails);
+    afterRunService.toggleLike(fileId, user.getId());
+    return ResponseEntity.noContent().build();  // 204 No Content
+  }
+
+  private User getCurrentUser(@AuthenticationPrincipal UserDetails userDetails) {
+    String email = userDetails.getUsername();
+    return userRepository.findByEmail(email)
+        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_FOUND_USER));
+  }
+}

--- a/src/main/java/com/service/runnersmap/dto/AfterRunPictureDto.java
+++ b/src/main/java/com/service/runnersmap/dto/AfterRunPictureDto.java
@@ -1,0 +1,16 @@
+package com.service.runnersmap.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AfterRunPictureDto {
+
+  private String afterRunPictureUrl;  // 인증샷
+  private int likeCount;  // 좋아요 수
+}

--- a/src/main/java/com/service/runnersmap/dto/AfterRunPictureDto.java
+++ b/src/main/java/com/service/runnersmap/dto/AfterRunPictureDto.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class AfterRunPictureDto {
 
+  private Long fileId; // 인증샷 Id
   private String afterRunPictureUrl;  // 인증샷
   private int likeCount;  // 좋아요 수
 }

--- a/src/main/java/com/service/runnersmap/entity/AfterRunPicture.java
+++ b/src/main/java/com/service/runnersmap/entity/AfterRunPicture.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -38,5 +39,8 @@ public class AfterRunPicture {
   private LocalDateTime createdAt;
 
   private Integer likeCount = 0;  // 좋아요 수, 기본값 0
+
+  @Version
+  private Long version;
 
 }

--- a/src/main/java/com/service/runnersmap/entity/Likes.java
+++ b/src/main/java/com/service/runnersmap/entity/Likes.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Version;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,5 +31,8 @@ public class Likes {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "users_id")
   private User user;
+
+  @Version
+  private Long version;
 
 }

--- a/src/main/java/com/service/runnersmap/repository/LikesRepository.java
+++ b/src/main/java/com/service/runnersmap/repository/LikesRepository.java
@@ -11,4 +11,6 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
   // 특정 사용자가 특정 인증샷에 공감을 했는지 확인
   Optional<Likes> findByAfterRunPictureAndUser(AfterRunPicture afterRunPicture, User user);
 
+  // 특정 인증샷에 대한 좋아요 수 계산
+  int countByAfterRunPicture(AfterRunPicture afterRunPicture);
 }

--- a/src/main/java/com/service/runnersmap/service/AfterRunService.java
+++ b/src/main/java/com/service/runnersmap/service/AfterRunService.java
@@ -63,7 +63,9 @@ public class AfterRunService {
 
     AfterRunPicture savedAfterRunPicture =  afterRunPictureRepository.save(afterRunPicture);
     return AfterRunPictureDto.builder()
+        .fileId(savedAfterRunPicture.getId())
         .afterRunPictureUrl(savedAfterRunPicture.getAfterRunPictureUrl())
+        .likeCount(0)
         .build();
   }
 

--- a/src/main/java/com/service/runnersmap/service/AfterRunService.java
+++ b/src/main/java/com/service/runnersmap/service/AfterRunService.java
@@ -1,5 +1,6 @@
 package com.service.runnersmap.service;
 
+import com.service.runnersmap.dto.AfterRunPictureDto;
 import com.service.runnersmap.entity.AfterRunPicture;
 import com.service.runnersmap.entity.Likes;
 import com.service.runnersmap.entity.Post;
@@ -10,6 +11,7 @@ import com.service.runnersmap.repository.LikesRepository;
 import com.service.runnersmap.repository.PostRepository;
 import com.service.runnersmap.repository.UserRepository;
 import com.service.runnersmap.type.ErrorCode;
+import jakarta.persistence.OptimisticLockException;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -28,79 +30,95 @@ public class AfterRunService {
   private final UserRepository userRepository;
   private final PostRepository postRepository;
 
-//  /**
-//   * 인증샷 업로드 그룹장이 ‘러닝 종료’ 버튼을 클릭시, 그룹장에게만 인증샷 업로드 버튼이 제공됨
-//   */
-//  public AfterRunPicture createAfterRunPhoto(Long postId, Long userId, MultipartFile file)
-//      throws IOException {
-//
-//    // 모집글 유무 확인
-//    Post post = postRepository.findById(postId)
-//        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_FOUND_POST_DATA));
-//
-//    // 그룹장 권한 체크
-//    if (!post.getAdmin().getId().equals(userId)) {
-//      throw new RunnersMapException(ErrorCode.OWNER_ONLY_ACCESS_POST_DATA);
-//    }
-//
-//    // 도착 여부 확인
-//    if (!post.getArriveYn()) {
-//      throw new RunnersMapException(ErrorCode.NOT_FINISHED_RUNNING);
-//    }
-//
-//    // S3에 인증샷 업로드 -> url 받아옴
-//    String afterRunPictureUrl = fileStorageService.uploadFile(file);
-//
-//    AfterRunPicture afterRunPicture = AfterRunPicture.builder()
-//        .user(post.getAdmin())
-//        .post(post)
-//        .afterRunPictureUrl(afterRunPictureUrl)
-//        .createdAt(LocalDateTime.now())
-//        .build();
-//
-//    return afterRunPictureRepository.save(afterRunPicture);
-//  }
-//
-//  /**
-//   * 인증샷 조회 - 모든 이용자가 조회 가능
-//   */
-//  public AfterRunPicture viewAfterRunPhoto(Long postId) {
-//
-//    Post post = postRepository.findById(postId)
-//        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_FOUND_POST_DATA));
-//
-//    return afterRunPictureRepository.findByPost(post)
-//        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_FOUND_FILE_DATA));
-//  }
-//
-//  /**
-//   * 인증샷에 좋아요 모든 이용자가 누를 수 있음 토글 형식 (두 번 누를 시 좋아요 취소)
-//   */
-//  @Transactional
-//  public void toggleLike(Long fileId, Long userId) {
-//
-//    User user = userRepository.findById(userId)
-//        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_FOUND_USER));
-//
-//    AfterRunPicture file = afterRunPictureRepository.findById(fileId)
-//        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_FOUND_FILE_DATA));
-//
-//    // 이미 좋아요 눌렀는지 확인
-//    Optional<Likes> alreadyLiked = likesRepository.findByAfterRunPictureAndUser(file, user);
-//    // 있으면 취소, 없으면 추가
-//    if (alreadyLiked.isPresent()) {
-//      likesRepository.delete(alreadyLiked.get());
-//      file.setLikeCount(file.getLikeCount() - 1);
-//    } else {
-//      Likes newlikes = Likes.builder()
-//          .afterRunPicture(file)
-//          .user(user)
-//          .build();
-//      likesRepository.save(newlikes);
-//      file.setLikeCount(file.getLikeCount() + 1);
-//    }
-//    afterRunPictureRepository.save(file);
-//  }
+  /**
+   * 인증샷 업로드 그룹장이 ‘러닝 종료’ 버튼을 클릭시, 그룹장에게만 인증샷 업로드 버튼이 제공됨
+   */
+  @Transactional
+  public AfterRunPictureDto createAfterRunPicture(Long postId, Long userId, MultipartFile file)
+      throws IOException {
+
+    // 모집글 유무 확인
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_FOUND_POST_DATA));
+
+    // 그룹장 권한 체크
+    if (!post.getAdmin().getId().equals(userId)) {
+      throw new RunnersMapException(ErrorCode.OWNER_ONLY_ACCESS_POST_DATA);
+    }
+
+    // 도착 여부 확인
+    if (!post.getArriveYn()) {
+      throw new RunnersMapException(ErrorCode.NOT_FINISHED_RUNNING);
+    }
+
+    // S3에 인증샷 업로드 -> url 받아옴
+    String afterRunPictureUrl = fileStorageService.uploadFile(file);
+
+    AfterRunPicture afterRunPicture = AfterRunPicture.builder()
+        .user(post.getAdmin())
+        .post(post)
+        .afterRunPictureUrl(afterRunPictureUrl)
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    AfterRunPicture savedAfterRunPicture =  afterRunPictureRepository.save(afterRunPicture);
+    return AfterRunPictureDto.builder()
+        .afterRunPictureUrl(savedAfterRunPicture.getAfterRunPictureUrl())
+        .build();
+  }
+
+  /**
+   * 인증샷 조회 - 모든 이용자가 조회 가능 좋아요 수도 반환
+   */
+  public AfterRunPictureDto viewAfterRunPicture(Long postId) {
+
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_FOUND_POST_DATA));
+
+    AfterRunPicture afterRunPicture = afterRunPictureRepository.findByPost(post)
+        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_FOUND_FILE_DATA));
+
+    int likeCount = likesRepository.countByAfterRunPicture(afterRunPicture);
+
+    return AfterRunPictureDto.builder()
+        .afterRunPictureUrl(afterRunPicture.getAfterRunPictureUrl())
+        .likeCount(likeCount)
+        .build();
+  }
+
+  /**
+   * 인증샷에 좋아요 모든 이용자가 누를 수 있음 토글 형식 (두 번 누를 시 좋아요 취소)
+   */
+  @Transactional
+  public void toggleLike(Long fileId, Long userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_FOUND_USER));
+
+    AfterRunPicture afterRunPicture = afterRunPictureRepository.findById(fileId)
+        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_FOUND_FILE_DATA));
+
+    try {
+    // 이미 좋아요 눌렀는지 확인
+    Optional<Likes> alreadyLiked = likesRepository.findByAfterRunPictureAndUser(afterRunPicture,
+        user);
+    // 있으면 취소, 없으면 추가
+      if (alreadyLiked.isPresent()) {
+        likesRepository.delete(alreadyLiked.get());
+        afterRunPicture.setLikeCount(afterRunPicture.getLikeCount() - 1); // 좋아요 수 감소
+      } else {
+        Likes newlikes = Likes.builder()
+            .afterRunPicture(afterRunPicture)
+            .user(user)
+            .build();
+        likesRepository.save(newlikes);
+        afterRunPicture.setLikeCount(afterRunPicture.getLikeCount() + 1); // 좋아요 수 증가
+      }
+      afterRunPictureRepository.save(afterRunPicture);
+    } catch (OptimisticLockException e) {
+      throw new RunnersMapException(ErrorCode.CONCURRENCY_CONTROL);
+    }
+  }
 }
+
 
 

--- a/src/main/java/com/service/runnersmap/type/ErrorCode.java
+++ b/src/main/java/com/service/runnersmap/type/ErrorCode.java
@@ -52,7 +52,9 @@ public enum ErrorCode {
   WRITER_ONLY_ACCESS_COMMENT_DATA("댓글 작성자만 수정/삭제가 가능합니다."),
 
   // 파일 관련 에러코드
-  NOT_FOUND_FILE_DATA("파일을 찾을 수 없습니다.")
+  NOT_FOUND_FILE_DATA("파일을 찾을 수 없습니다."),
+
+  CONCURRENCY_CONTROL("처리중인 요청이 너무 많습니다. 다시 시도해주세요")
   ;
 
   private final String description;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
1. 러닝을 마친 그룹장만 인증샷을 업로드할 수 있습니다.
2. 인증샷은 모집글로 조회하면 볼 수 있게 해 두었습니다. 로그인 없이도 누구나 볼 수 있습니다.
3. 인증샷에 대한 좋아요
    -  로그인 한 회원만 이용할 수 있게 했습니다. 
    -  토글형식입니다. (두 번 누르면 좋아요 취소)
    - 동시성 문제를 해결하기 위해 낙관적 락을 사용했습니다. 
    빈번하게 눌릴 것이라 예상될 상황이 없기 때문에 버전 관리로 충분할 것이라 생각했습니다. 

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
